### PR TITLE
fix: extended matrix configuration type to make it simpler

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "pnpm run clean && pnpm run compile",
     "clean": "rm -rf ./build",
     "compile": "tsc -p tsconfig.build.json",
-    "generate-workflow-types": "ts-node scripts/generateWorkflowTypes.ts && pnpx eslint --fix src/types/githubActionsWorkflow.ts",
+    "generate-workflow-types": "ts-node scripts/generateWorkflowTypes.ts && pnpm exec eslint --fix src/types/githubActionsWorkflow.ts",
     "generate-workflow-files": "node build/bin.js build",
     "gwf": "node build/bin.js",
     "prepare": "husky install"
@@ -52,6 +52,9 @@
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
     "eslint": "^8.47.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-jest": "^28.8.3",
+    "eslint-plugin-prettier": "^5.2.1",
     "husky": "^8.0.0",
     "jest": "^28.1.2",
     "json-schema-to-typescript": "^10.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,15 @@ devDependencies:
   eslint:
     specifier: ^8.47.0
     version: 8.47.0
+  eslint-config-prettier:
+    specifier: ^9.1.0
+    version: 9.1.0(eslint@8.47.0)
+  eslint-plugin-jest:
+    specifier: ^28.8.3
+    version: 28.8.3(@typescript-eslint/eslint-plugin@6.4.0)(eslint@8.47.0)(jest@28.1.2)(typescript@4.5.2)
+  eslint-plugin-prettier:
+    specifier: ^5.2.1
+    version: 5.2.1(eslint-config-prettier@9.1.0)(eslint@8.47.0)(prettier@3.0.2)
   husky:
     specifier: ^8.0.0
     version: 8.0.0
@@ -994,6 +1003,11 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
+  /@pkgr/core@0.1.1:
+    resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    dev: true
+
   /@sinclair/typebox@0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
     dev: true
@@ -1917,6 +1931,58 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /eslint-config-prettier@9.1.0(eslint@8.47.0):
+    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.47.0
+    dev: true
+
+  /eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@6.4.0)(eslint@8.47.0)(jest@28.1.2)(typescript@4.5.2):
+    resolution: {integrity: sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==}
+    engines: {node: ^16.10.0 || ^18.12.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)(typescript@4.5.2)
+      '@typescript-eslint/utils': 6.4.0(eslint@8.47.0)(typescript@4.5.2)
+      eslint: 8.47.0
+      jest: 28.1.2(@types/node@20.5.6)(ts-node@10.8.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /eslint-plugin-prettier@5.2.1(eslint-config-prettier@9.1.0)(eslint@8.47.0)(prettier@3.0.2):
+    resolution: {integrity: sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '*'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 8.47.0
+      eslint-config-prettier: 9.1.0(eslint@8.47.0)
+      prettier: 3.0.2
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.9.1
+    dev: true
+
   /eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2080,6 +2146,10 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
+
+  /fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
     dev: true
 
   /fast-glob@3.2.11:
@@ -3539,6 +3609,13 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /prettier-linter-helpers@1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      fast-diff: 1.3.0
+    dev: true
+
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -3913,6 +3990,14 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /synckit@0.9.1:
+    resolution: {integrity: sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    dependencies:
+      '@pkgr/core': 0.1.1
+      tslib: 2.7.0
+    dev: true
+
   /terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
@@ -4093,6 +4178,10 @@ packages:
       typescript: 4.5.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  /tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+    dev: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/src/types/githubActionsWorkflowExtended.ts
+++ b/src/types/githubActionsWorkflowExtended.ts
@@ -1,4 +1,4 @@
-import { NormalJob } from './githubActionsWorkflow'
+import { NormalJob, Configuration } from './githubActionsWorkflow'
 
 /**
  * Non-generated types
@@ -18,3 +18,5 @@ export type Step = ElementOf<NormalJob['steps']>
  *
  */
 export type Steps = NormalJob['steps']
+
+export type MatrixConfiguration = string | [Configuration, ...Configuration[]]

--- a/workflows/test.wac.ts
+++ b/workflows/test.wac.ts
@@ -1,6 +1,12 @@
-import { Workflow, NormalJob, Step, expressions as ex } from '../'
+import {
+	Workflow,
+	NormalJob,
+	Step,
+	expressions as ex,
+	ExtendedWorkflowTypes,
+} from '../'
 
-const nodeVersions = [16, 18, 20]
+const nodeVersions: ExtendedWorkflowTypes.MatrixConfiguration = [16, 18, 20]
 
 const checkout = new Step({
 	name: 'Checkout',


### PR DESCRIPTION
- Fixes the `pnpm generate-workflow-types` command by adding the correct execution context (using local deps) as well as adding the dependencies local package execution context depends on.
- Extends the `GeneratedWorkflowTypes.Configuration via `ExtendedWorkflowTypes.MatrixConfiguration` to make adding the new matrix properties easier (and not have to do type gymnastics)
