### PR TITLE
fix: fixes glob search on Windows by removing slashes from search pattern

### DIFF
--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -73,7 +73,7 @@ export const getConfig = (): BuildTypes.WacConfig | undefined => {
  */
 export const getWorkflowFilePaths = (): string[] | undefined => {
 	const workflowFilesPaths = fg.sync(
-		path.join(process.cwd(), '**', '*.wac.ts'),
+		fg.convertPathToPattern(process.cwd()) + '/**/*.wac.ts',
 		{
 			onlyFiles: true,
 			dot: true,


### PR DESCRIPTION
Remove slashes from search pattern to make glob search pattern OS agnostic

Closes #34 