### PR TITLE
fix: allow pinning action version

### DIFF
--- a/packages/actions/scripts/generate.ts
+++ b/packages/actions/scripts/generate.ts
@@ -388,13 +388,13 @@ export class ${className} extends BaseAction<'${uses}', ${className}Outputs> {
     const outputNames = ${outputNamesArray}
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: '${uses}',
+        uses: uses ?? '${uses}',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/cache/v3.ts
+++ b/packages/actions/src/generated/actions/cache/v3.ts
@@ -56,13 +56,13 @@ export class ActionsCacheV3 extends BaseAction<
     const outputNames = ['cache-hit'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/cache@v3',
+        uses: uses ?? 'actions/cache@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/cache/v4.ts
+++ b/packages/actions/src/generated/actions/cache/v4.ts
@@ -59,13 +59,13 @@ export class ActionsCacheV4 extends BaseAction<
     const outputNames = ['cache-hit'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/cache@v4',
+        uses: uses ?? 'actions/cache@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/checkout/v3.ts
+++ b/packages/actions/src/generated/actions/checkout/v3.ts
@@ -76,13 +76,13 @@ export class ActionsCheckoutV3 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/checkout@v3',
+        uses: uses ?? 'actions/checkout@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/checkout/v4.ts
+++ b/packages/actions/src/generated/actions/checkout/v4.ts
@@ -82,13 +82,13 @@ export class ActionsCheckoutV4 extends BaseAction<
     const outputNames = ['ref', 'commit'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/checkout@v4',
+        uses: uses ?? 'actions/checkout@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/checkout/v5.ts
+++ b/packages/actions/src/generated/actions/checkout/v5.ts
@@ -82,13 +82,13 @@ export class ActionsCheckoutV5 extends BaseAction<
     const outputNames = ['ref', 'commit'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/checkout@v5',
+        uses: uses ?? 'actions/checkout@v5',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/checkout/v6.ts
+++ b/packages/actions/src/generated/actions/checkout/v6.ts
@@ -82,13 +82,13 @@ export class ActionsCheckoutV6 extends BaseAction<
     const outputNames = ['ref', 'commit'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/checkout@v6',
+        uses: uses ?? 'actions/checkout@v6',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/download-artifact/v3.ts
+++ b/packages/actions/src/generated/actions/download-artifact/v3.ts
@@ -48,13 +48,13 @@ export class ActionsDownloadArtifactV3 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/download-artifact@v3',
+        uses: uses ?? 'actions/download-artifact@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/download-artifact/v4.ts
+++ b/packages/actions/src/generated/actions/download-artifact/v4.ts
@@ -60,13 +60,13 @@ export class ActionsDownloadArtifactV4 extends BaseAction<
     const outputNames = ['download-path'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/download-artifact@v4',
+        uses: uses ?? 'actions/download-artifact@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/github-script/v6.ts
+++ b/packages/actions/src/generated/actions/github-script/v6.ts
@@ -60,13 +60,13 @@ export class ActionsGithubScriptV6 extends BaseAction<
     const outputNames = ['result'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/github-script@v6',
+        uses: uses ?? 'actions/github-script@v6',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/github-script/v7.ts
+++ b/packages/actions/src/generated/actions/github-script/v7.ts
@@ -62,13 +62,13 @@ export class ActionsGithubScriptV7 extends BaseAction<
     const outputNames = ['result'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/github-script@v7',
+        uses: uses ?? 'actions/github-script@v7',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/github-script/v8.ts
+++ b/packages/actions/src/generated/actions/github-script/v8.ts
@@ -62,13 +62,13 @@ export class ActionsGithubScriptV8 extends BaseAction<
     const outputNames = ['result'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/github-script@v8',
+        uses: uses ?? 'actions/github-script@v8',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/setup-node/v3.ts
+++ b/packages/actions/src/generated/actions/setup-node/v3.ts
@@ -62,13 +62,13 @@ export class ActionsSetupNodeV3 extends BaseAction<
     const outputNames = ['cache-hit', 'node-version'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/setup-node@v3',
+        uses: uses ?? 'actions/setup-node@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/setup-node/v4.ts
+++ b/packages/actions/src/generated/actions/setup-node/v4.ts
@@ -66,13 +66,13 @@ export class ActionsSetupNodeV4 extends BaseAction<
     const outputNames = ['cache-hit', 'node-version'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/setup-node@v4',
+        uses: uses ?? 'actions/setup-node@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/setup-python/v4.ts
+++ b/packages/actions/src/generated/actions/setup-python/v4.ts
@@ -63,13 +63,13 @@ export class ActionsSetupPythonV4 extends BaseAction<
     const outputNames = ['python-version', 'cache-hit', 'python-path'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/setup-python@v4',
+        uses: uses ?? 'actions/setup-python@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/setup-python/v5.ts
+++ b/packages/actions/src/generated/actions/setup-python/v5.ts
@@ -65,13 +65,13 @@ export class ActionsSetupPythonV5 extends BaseAction<
     const outputNames = ['python-version', 'cache-hit', 'python-path'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/setup-python@v5',
+        uses: uses ?? 'actions/setup-python@v5',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/upload-artifact/v3.ts
+++ b/packages/actions/src/generated/actions/upload-artifact/v3.ts
@@ -54,13 +54,13 @@ export class ActionsUploadArtifactV3 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/upload-artifact@v3',
+        uses: uses ?? 'actions/upload-artifact@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/actions/upload-artifact/v4.ts
+++ b/packages/actions/src/generated/actions/upload-artifact/v4.ts
@@ -65,13 +65,13 @@ export class ActionsUploadArtifactV4 extends BaseAction<
     ] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'actions/upload-artifact@v4',
+        uses: uses ?? 'actions/upload-artifact@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/aws-actions/amazon-ecr-login/v2.ts
+++ b/packages/actions/src/generated/aws-actions/amazon-ecr-login/v2.ts
@@ -54,13 +54,13 @@ export class AwsActionsAmazonEcrLoginV2 extends BaseAction<
     const outputNames = ['registry'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'aws-actions/amazon-ecr-login@v2',
+        uses: uses ?? 'aws-actions/amazon-ecr-login@v2',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/aws-actions/amazon-ecs-deploy-task-definition/v2.ts
+++ b/packages/actions/src/generated/aws-actions/amazon-ecs-deploy-task-definition/v2.ts
@@ -109,13 +109,13 @@ export class AwsActionsAmazonEcsDeployTaskDefinitionV2 extends BaseAction<
     ] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'aws-actions/amazon-ecs-deploy-task-definition@v2',
+        uses: uses ?? 'aws-actions/amazon-ecs-deploy-task-definition@v2',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/aws-actions/amazon-ecs-render-task-definition/v1.ts
+++ b/packages/actions/src/generated/aws-actions/amazon-ecs-render-task-definition/v1.ts
@@ -70,13 +70,13 @@ export class AwsActionsAmazonEcsRenderTaskDefinitionV1 extends BaseAction<
     const outputNames = ['task-definition'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'aws-actions/amazon-ecs-render-task-definition@v1',
+        uses: uses ?? 'aws-actions/amazon-ecs-render-task-definition@v1',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/aws-actions/aws-cloudformation-github-deploy/v1.ts
+++ b/packages/actions/src/generated/aws-actions/aws-cloudformation-github-deploy/v1.ts
@@ -74,13 +74,13 @@ export class AwsActionsAwsCloudformationGithubDeployV1 extends BaseAction<
     const outputNames = ['stack-id'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'aws-actions/aws-cloudformation-github-deploy@v1',
+        uses: uses ?? 'aws-actions/aws-cloudformation-github-deploy@v1',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/aws-actions/aws-codebuild-run-build/v1.ts
+++ b/packages/actions/src/generated/aws-actions/aws-codebuild-run-build/v1.ts
@@ -78,13 +78,13 @@ export class AwsActionsAwsCodebuildRunBuildV1 extends BaseAction<
     const outputNames = ['aws-build-id'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'aws-actions/aws-codebuild-run-build@v1',
+        uses: uses ?? 'aws-actions/aws-codebuild-run-build@v1',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/aws-actions/configure-aws-credentials/v3.ts
+++ b/packages/actions/src/generated/aws-actions/configure-aws-credentials/v3.ts
@@ -95,13 +95,13 @@ export class AwsActionsConfigureAwsCredentialsV3 extends BaseAction<
     ] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'aws-actions/configure-aws-credentials@v3',
+        uses: uses ?? 'aws-actions/configure-aws-credentials@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/aws-actions/configure-aws-credentials/v4.ts
+++ b/packages/actions/src/generated/aws-actions/configure-aws-credentials/v4.ts
@@ -101,13 +101,13 @@ export class AwsActionsConfigureAwsCredentialsV4 extends BaseAction<
     ] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'aws-actions/configure-aws-credentials@v4',
+        uses: uses ?? 'aws-actions/configure-aws-credentials@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/docker/build-push-action/v5.ts
+++ b/packages/actions/src/generated/docker/build-push-action/v5.ts
@@ -108,13 +108,13 @@ export class DockerBuildPushActionV5 extends BaseAction<
     const outputNames = ['imageid', 'digest', 'metadata'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'docker/build-push-action@v5',
+        uses: uses ?? 'docker/build-push-action@v5',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/docker/build-push-action/v6.ts
+++ b/packages/actions/src/generated/docker/build-push-action/v6.ts
@@ -110,13 +110,13 @@ export class DockerBuildPushActionV6 extends BaseAction<
     const outputNames = ['imageid', 'digest', 'metadata'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'docker/build-push-action@v6',
+        uses: uses ?? 'docker/build-push-action@v6',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/docker/login-action/v2.ts
+++ b/packages/actions/src/generated/docker/login-action/v2.ts
@@ -52,13 +52,13 @@ export class DockerLoginActionV2 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'docker/login-action@v2',
+        uses: uses ?? 'docker/login-action@v2',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/docker/login-action/v3.ts
+++ b/packages/actions/src/generated/docker/login-action/v3.ts
@@ -54,13 +54,13 @@ export class DockerLoginActionV3 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'docker/login-action@v3',
+        uses: uses ?? 'docker/login-action@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/docker/setup-buildx-action/v2.ts
+++ b/packages/actions/src/generated/docker/setup-buildx-action/v2.ts
@@ -83,13 +83,13 @@ export class DockerSetupBuildxActionV2 extends BaseAction<
     ] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'docker/setup-buildx-action@v2',
+        uses: uses ?? 'docker/setup-buildx-action@v2',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/docker/setup-buildx-action/v3.ts
+++ b/packages/actions/src/generated/docker/setup-buildx-action/v3.ts
@@ -96,13 +96,13 @@ export class DockerSetupBuildxActionV3 extends BaseAction<
     ] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'docker/setup-buildx-action@v3',
+        uses: uses ?? 'docker/setup-buildx-action@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/github/codeql-action/v2.ts
+++ b/packages/actions/src/generated/github/codeql-action/v2.ts
@@ -41,13 +41,13 @@ export class GithubCodeqlActionV2 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'github/codeql-action@v2',
+        uses: uses ?? 'github/codeql-action@v2',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/github/codeql-action/v3.ts
+++ b/packages/actions/src/generated/github/codeql-action/v3.ts
@@ -41,13 +41,13 @@ export class GithubCodeqlActionV3 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'github/codeql-action@v3',
+        uses: uses ?? 'github/codeql-action@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/peaceiris/actions-gh-pages/v3.ts
+++ b/packages/actions/src/generated/peaceiris/actions-gh-pages/v3.ts
@@ -84,13 +84,13 @@ export class PeaceirisActionsGhPagesV3 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'peaceiris/actions-gh-pages@v3',
+        uses: uses ?? 'peaceiris/actions-gh-pages@v3',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/peaceiris/actions-gh-pages/v4.ts
+++ b/packages/actions/src/generated/peaceiris/actions-gh-pages/v4.ts
@@ -84,13 +84,13 @@ export class PeaceirisActionsGhPagesV4 extends BaseAction<
     const outputNames = [] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'peaceiris/actions-gh-pages@v4',
+        uses: uses ?? 'peaceiris/actions-gh-pages@v4',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/release-drafter/release-drafter/v6.ts
+++ b/packages/actions/src/generated/release-drafter/release-drafter/v6.ts
@@ -91,13 +91,13 @@ export class ReleaseDrafterReleaseDrafterV6 extends BaseAction<
     ] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'release-drafter/release-drafter@v6',
+        uses: uses ?? 'release-drafter/release-drafter@v6',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/softprops/action-gh-release/v1.ts
+++ b/packages/actions/src/generated/softprops/action-gh-release/v1.ts
@@ -76,13 +76,13 @@ export class SoftpropsActionGhReleaseV1 extends BaseAction<
     const outputNames = ['url', 'id', 'upload_url', 'assets'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'softprops/action-gh-release@v1',
+        uses: uses ?? 'softprops/action-gh-release@v1',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,

--- a/packages/actions/src/generated/softprops/action-gh-release/v2.ts
+++ b/packages/actions/src/generated/softprops/action-gh-release/v2.ts
@@ -84,13 +84,13 @@ export class SoftpropsActionGhReleaseV2 extends BaseAction<
     const outputNames = ['url', 'id', 'upload_url', 'assets'] as const
 
     // Destructure to control property order in output
-    const { id, name, with: withProps, env, ...rest } = props
+    const { id, name, with: withProps, env, uses, ...rest } = props
 
     super(
       {
         ...(name !== undefined && { name }),
         ...(id !== undefined && { id }),
-        uses: 'softprops/action-gh-release@v2',
+        uses: uses ?? 'softprops/action-gh-release@v2',
         ...(withProps !== undefined && { with: withProps }),
         ...(env !== undefined && { env }),
         ...rest,


### PR DESCRIPTION
Often, developers prefer to pin an exact version of an action e.g.:

```patch
- uses: actions/checkout@v6
+ uses: actions/checkout@v6.0.1
```

However, this currently causes a type error, and even if the type error is mitigated by casting (see below) the provided uses string is discarded at runtime.

```ts
// This doesn't work - will still output "actions/checkout@v6"
uses: "actions/checkout@v6.0.1" as "actions/checkout@v6",
```

This PR enables specifying either the default value (e.g. `"actions/checkout@v6"`), or a specific version (e.g. `"actions/checkout@v6.0.1"`).

Auto-complete in IDEs is preserved by using the `& {}` trick.

### Note on soundness of generated types

Since semantic version constraints only apply "forwards", the type guarantees provided by the `Props` interface only apply to the version of the action from which the interface was generated or later versions. The type may be unsound for previous versions. For instance, if a new input was added in `v1.2.3`, and we were to generate types based on this version, the generated types would be sound for all versions after `v1.2.3` (assuming correct use of semantic versioning), but not for any versions before `v1.2.3`.

I'm not sure how dogmatic you are about these kinds of type soundness corner cases. My personal view is that this is fine, though perhaps updating the comment to explain this would be worthwhile.

In any case, I'm not sure there's a sane way to represent semantic version constraints in TypeScript, so the alternative would be to change the type to e.g. `"actions/checkout@v6" | "actions/checkout@v6.0.1"` which would allow pinning, but would discourage bumping the version regularly since this would require either a package update or type cast. IMO this isn't a good tradeoff, hence the implementation in this PR.