### PR TITLE
fix: skip version bump commit for prerelease versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,7 @@ jobs:
     timeout-minutes: 20
     needs:
       - PublishPackages
+    if: '!github.event.release.prerelease'
     permissions:
       contents: write
     steps:

--- a/workflows/publish.wac.ts
+++ b/workflows/publish.wac.ts
@@ -101,6 +101,7 @@ const commitVersionBumpJob = new NormalJob('CommitVersionBump', {
   'runs-on': 'ubuntu-latest',
   'timeout-minutes': 20,
   needs: [publishJob.name],
+  if: '!github.event.release.prerelease',
   permissions: {
     contents: 'write',
   },


### PR DESCRIPTION
## Summary
- Skip the `CommitVersionBump` job for alpha and beta prerelease versions
- Version bumps will only be committed to main for stable releases

## Test plan
- [x] Verify the `if` condition in the generated `publish.yml` workflow
- [x] Test with a beta release to confirm the commit bump job is skipped

🤖 Generated with [Claude Code](https://claude.ai/code)