### PR TITLE
chore: add docs workspace placeholder for Vercel setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation Site
+
+This directory will contain the Docusaurus documentation site for `github-actions-workflow-ts`.
+
+## Status
+
+This is a placeholder to enable Vercel project setup. The full documentation site is being developed in PR #75.
+
+## Coming Soon
+
+- Getting Started guides
+- API Reference (auto-generated from TypeDoc)
+- Core Concepts documentation
+- Contributing guides

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "docs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo 'Placeholder - full docs coming in PR #75'"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/*'
+  - 'docs'


### PR DESCRIPTION
## Summary

Add minimal `docs/` directory structure to enable Vercel project configuration.

This PR adds:
- `docs/README.md` - Placeholder README
- `docs/package.json` - Minimal package.json with placeholder build script
- Updated `pnpm-workspace.yaml` to include docs

## Why

Vercel needs the `docs/` directory to exist in `main` branch before we can set up the project and get the required credentials (`VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).

## Next Steps

1. Merge this PR
2. Set up Vercel project pointing to `docs/` directory
3. Add GitHub secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
4. Merge PR #75 with the full documentation site