### PR TITLE
feat: resolve output paths from project root

### DIFF
--- a/docs/docs/guides/configuration.md
+++ b/docs/docs/guides/configuration.md
@@ -162,6 +162,47 @@ Output paths are resolved in this order (highest priority first):
 3. Config `outputPaths.workflows.default`
 4. Default `.github/workflows`
 
+All relative paths are resolved from the **project root** (not the current working directory). See [rootDir](#rootdir) for details.
+
+### rootDir
+
+The root directory for resolving output paths. By default, the project root is auto-detected by looking for a `.git` directory or a `package.json` with `workspaces` defined.
+
+| Type | Default |
+|------|---------|
+| `string` | Auto-detected project root |
+
+This is useful when running `gwf` from a subdirectory but wanting output paths relative to the project root.
+
+```typescript
+// wac.config.ts - running from scripts/githubactions/
+const config: WacConfig = {
+  rootDir: '../..', // Go up to project root
+  outputPaths: {
+    workflows: {
+      default: '.github/workflows', // Resolves to <project-root>/.github/workflows
+    },
+  },
+}
+```
+
+**Example structure:**
+```
+my-project/                          # Project root (has .git/)
+├── .github/workflows/               # Shared workflows go here
+├── scripts/
+│   └── githubactions/
+│       ├── ci.wac.ts
+│       ├── deploy.wac.ts
+│       ├── wac.config.ts            # Config with rootDir: '../..'
+│       └── package.json             # Has "gwf build" script
+└── packages/
+    └── app-a/
+        └── .github/workflows/       # App-specific workflows
+```
+
+Without `rootDir`, paths would resolve relative to `scripts/githubactions/`. With `rootDir: '../..'`, paths resolve from `my-project/`.
+
 ### diagnostics
 
 Configure diagnostic warnings emitted during build when using `@github-actions-workflow-ts/actions`.

--- a/packages/cli/src/commands/types/build.ts
+++ b/packages/cli/src/commands/types/build.ts
@@ -85,4 +85,16 @@ export type WacConfig = {
    * Allows workflows to be written to different directories based on filename patterns.
    */
   outputPaths?: OutputPathsConfig
+  /**
+   * Root directory for resolving output paths.
+   * If not specified, automatically detected by finding the nearest .git directory
+   * or package.json with workspaces.
+   *
+   * This is useful when running gwf from a subdirectory (e.g., scripts/) but
+   * wanting output paths to be relative to the project root.
+   *
+   * @example "../../" - Go up two directories from cwd
+   * @example "/absolute/path/to/project" - Use an absolute path
+   */
+  rootDir?: string
 }


### PR DESCRIPTION
## Summary

Output paths are now resolved relative to the **project root** instead of the current working directory. This addresses the issue where running `gwf` from a subdirectory (e.g., `scripts/`) would cause paths like `.github/workflows` to resolve incorrectly.

Closes #89 (specifically [this comment](https://github.com/emmanuelnk/github-actions-workflow-ts/issues/89#issuecomment-3816062222))

## Changes

### Auto-detection of project root

The project root is automatically detected by looking for:
1. A `.git` directory (most reliable)
2. A `package.json` with `workspaces` defined (monorepo root)

If neither is found, falls back to the current working directory.

### New `rootDir` config option

For explicit control, you can set `rootDir` in your config:

```typescript
// wac.config.ts - running from scripts/githubactions/
const config: WacConfig = {
  rootDir: '../..', // Go up to project root
  outputPaths: {
    workflows: {
      default: '.github/workflows', // Resolves to <project-root>/.github/workflows
    },
  },
}
```

### Example structure

```
my-project/                          # Project root (has .git/)
├── .github/workflows/               # Shared workflows go here
├── scripts/
│   └── githubactions/
│       ├── ci.wac.ts
│       ├── deploy.wac.ts
│       ├── wac.config.ts            # Config with rootDir: '../..'
│       └── package.json             # Has "gwf build" script
└── packages/
    └── app-a/
        └── .github/workflows/       # App-specific workflows
```

**Before:** Running `gwf build` from `scripts/githubactions/` would write to `scripts/githubactions/.github/workflows/`

**After:** Paths resolve from the auto-detected project root (`my-project/`), so `.github/workflows` correctly writes to `my-project/.github/workflows/`

## Test plan

- [x] Unit tests for `findProjectRoot()` function
- [x] Unit tests for `resolveRootDir()` function  
- [x] Updated tests for `resolveOutputPath()` with rootDir parameter
- [x] Updated tests for `writeWorkflowJSONToYamlFiles()` with rootDir parameter
- [ ] Manual testing with subdirectory setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)