### PR TITLE
ci: call publish workflow from draft when creating pre-release

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -22,8 +22,11 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: write
+    outputs:
+      tag_name: ${{ steps.create_release.outputs.tag_name }}
     steps:
-      - name: Publish beta release
+      - id: create_release
+        name: Publish beta release
         uses: release-drafter/release-drafter@v5
         with:
           commitish: main
@@ -32,6 +35,18 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PublishBetaPackages:
+    uses: ./.github/workflows/publish.yml
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    with:
+      tag_name: ${{ needs.PublishBetaRelease.outputs.tag_name }}
+      target_commitish: ${{ github.sha }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    needs:
+      - PublishBetaRelease
   UpdateReleaseDraft:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -23,9 +23,9 @@ jobs:
     permissions:
       contents: write
     outputs:
-      tag_name: ${{ steps.create_release.outputs.tag_name }}
+      tag_name: ${{ steps.publish_beta_release.outputs.tag_name }}
     steps:
-      - id: create_release
+      - id: publish_beta_release
         name: Publish beta release
         uses: release-drafter/release-drafter@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,17 @@ name: Publish Release
   release:
     types:
       - published
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      target_commitish:
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
 jobs:
   PublishPackages:
     runs-on: ubuntu-latest
@@ -18,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: ${{ inputs.target_commitish || github.event.release.target_commitish }}
       - name: Install Node
         uses: actions/setup-node@v4
         with:
@@ -35,17 +46,17 @@ jobs:
         run: |-
           git config user.name github-actions
           git config user.email github-actions@github.com
-          echo version: ${{ github.event.release.tag_name }}
-          (cd packages/lib && npm version --no-git-tag-version ${{ github.event.release.tag_name }})
-          (cd packages/cli && npm version --no-git-tag-version ${{ github.event.release.tag_name }})
-          (cd packages/actions && npm version --no-git-tag-version ${{ github.event.release.tag_name }})
+          echo version: ${{ inputs.tag_name || github.event.release.tag_name }}
+          (cd packages/lib && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
+          (cd packages/cli && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
+          (cd packages/actions && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
       - name: Setup npm auth
         run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish packages
         run: |-
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_NAME="${{ inputs.tag_name || github.event.release.tag_name }}"
           if [[ "$TAG_NAME" == *"-alpha"* ]]; then
             echo "Publishing with alpha tag"
             pnpm -r publish --access public --tag alpha --no-git-checks
@@ -63,7 +74,7 @@ jobs:
     timeout-minutes: 20
     needs:
       - PublishPackages
-    if: '!github.event.release.prerelease'
+    if: '!contains(inputs.tag_name || github.event.release.tag_name, ''-'')'
     permissions:
       contents: write
     steps:
@@ -76,10 +87,10 @@ jobs:
         run: |-
           git config user.name github-actions
           git config user.email github-actions@github.com
-          echo version: ${{ github.event.release.tag_name }}
-          (cd packages/lib && npm version --no-git-tag-version ${{ github.event.release.tag_name }})
-          (cd packages/cli && npm version --no-git-tag-version ${{ github.event.release.tag_name }})
-          (cd packages/actions && npm version --no-git-tag-version ${{ github.event.release.tag_name }})
+          echo version: ${{ inputs.tag_name || github.event.release.tag_name }}
+          (cd packages/lib && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
+          (cd packages/cli && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
+          (cd packages/actions && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
           git add .
-          git commit -m "new release: ${{ github.event.release.tag_name }} [skip ci]" --no-verify
+          git commit -m "new release: ${{ inputs.tag_name || github.event.release.tag_name }} [skip ci]" --no-verify
           git push origin HEAD:main

--- a/workflows/draft.wac.ts
+++ b/workflows/draft.wac.ts
@@ -7,7 +7,7 @@ import {
 } from '../packages/lib/src/index.js'
 
 const betaReleaseStep = new Step({
-  id: 'create_release',
+  id: 'publish_beta_release',
   name: 'Publish beta release',
   uses: 'release-drafter/release-drafter@v5',
   with: {

--- a/workflows/draft.wac.ts
+++ b/workflows/draft.wac.ts
@@ -1,11 +1,13 @@
 import {
   Workflow,
   NormalJob,
+  ReusableWorkflowCallJob,
   Step,
   expressions as ex,
 } from '../packages/lib/src/index.js'
 
 const betaReleaseStep = new Step({
+  id: 'create_release',
   name: 'Publish beta release',
   uses: 'release-drafter/release-drafter@v5',
   with: {
@@ -26,7 +28,25 @@ const betaReleaseJob = new NormalJob('PublishBetaRelease', {
   permissions: {
     contents: 'write',
   },
+  outputs: {
+    tag_name: ex.expn(`steps.${betaReleaseStep.id}.outputs.tag_name`),
+  },
 }).addStep(betaReleaseStep)
+
+const publishBetaJob = new ReusableWorkflowCallJob('PublishBetaPackages', {
+  uses: './.github/workflows/publish.yml',
+  if: "github.event_name == 'push'",
+  permissions: {
+    contents: 'write',
+  },
+  with: {
+    tag_name: ex.expn(`needs.${betaReleaseJob.name}.outputs.tag_name`),
+    target_commitish: ex.expn('github.sha'),
+  },
+  secrets: {
+    NPM_TOKEN: ex.secret('NPM_TOKEN'),
+  },
+}).needs([betaReleaseJob])
 
 const draftStep = new Step({
   name: 'Draft next release',
@@ -67,4 +87,4 @@ export const draftWorkflow = new Workflow('draft', {
   permissions: {
     contents: 'read',
   },
-}).addJobs([betaReleaseJob, draftJob])
+}).addJobs([betaReleaseJob, publishBetaJob, draftJob])

--- a/workflows/publish.wac.ts
+++ b/workflows/publish.wac.ts
@@ -141,8 +141,8 @@ export const publishWorkflow = new Workflow('publish', {
     },
     workflow_call: {
       inputs: {
-        tag_name: { required: true, type: 'string' as const },
-        target_commitish: { required: true, type: 'string' as const },
+        tag_name: { required: true, type: 'string' },
+        target_commitish: { required: true, type: 'string' },
       },
       secrets: {
         NPM_TOKEN: { required: true },

--- a/workflows/publish.wac.ts
+++ b/workflows/publish.wac.ts
@@ -6,8 +6,10 @@ import {
   dedentString,
 } from '../packages/lib/src/index.js'
 
-const targetCommitish = ex.expn('github.event.release.target_commitish')
-const tagName = ex.expn('github.event.release.tag_name')
+const targetCommitish = ex.expn(
+  'inputs.target_commitish || github.event.release.target_commitish',
+)
+const tagName = ex.expn('inputs.tag_name || github.event.release.tag_name')
 
 const checkout = new Step({
   name: 'Checkout',
@@ -101,7 +103,8 @@ const commitVersionBumpJob = new NormalJob('CommitVersionBump', {
   'runs-on': 'ubuntu-latest',
   'timeout-minutes': 20,
   needs: [publishJob.name],
-  if: '!github.event.release.prerelease',
+  // Skip this on prereleases (i.e. any release with a "-" in it, like 1.2.3-beta.0)
+  if: "!contains(inputs.tag_name || github.event.release.tag_name, '-')",
   permissions: {
     contents: 'write',
   },
@@ -135,6 +138,15 @@ export const publishWorkflow = new Workflow('publish', {
   on: {
     release: {
       types: ['published'],
+    },
+    workflow_call: {
+      inputs: {
+        tag_name: { required: true, type: 'string' as const },
+        target_commitish: { required: true, type: 'string' as const },
+      },
+      secrets: {
+        NPM_TOKEN: { required: true },
+      },
     },
   },
 }).addJobs([publishJob, commitVersionBumpJob])


### PR DESCRIPTION
This is a follow on PR from https://github.com/emmanuelnk/github-actions-workflow-ts/pull/105.

Turns out, I did a derp. I thought I'd tested that the GH release created by release-drafter would trigger the publish workflow, but I didn't, and it doesn't. This is expected behavior as per the [GH docs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs):

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

A solution (the one implemented in this PR) is to explicitly call the `publish` workflow from the `draft` workflow.