### PR TITLE
ci: run release drafter for prereleases and stable releases concurrently

### DIFF
--- a/.github/release-drafter.prerelease.yml
+++ b/.github/release-drafter.prerelease.yml
@@ -1,0 +1,5 @@
+_extends: emmanuelnk/github-actions-workflow-ts:.github/release-drafter.yml
+
+# This ensures that the prerelease workflow won't modify draft releases for
+# stable versions.
+include-pre-releases: true

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -27,9 +27,10 @@ jobs:
     steps:
       - id: publish_beta_release
         name: Publish beta release
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v6
         with:
           commitish: main
+          config-name: release-drafter.prerelease.yml
           prerelease: true
           prerelease-identifier: beta
           publish: true
@@ -52,11 +53,9 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
-    needs:
-      - PublishBetaRelease
     steps:
       - name: Draft next release
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v6
         with:
           commitish: main
         env:

--- a/workflows/draft.wac.ts
+++ b/workflows/draft.wac.ts
@@ -9,9 +9,10 @@ import {
 const betaReleaseStep = new Step({
   id: 'publish_beta_release',
   name: 'Publish beta release',
-  uses: 'release-drafter/release-drafter@v5',
+  uses: 'release-drafter/release-drafter@v6',
   with: {
     commitish: 'main',
+    'config-name': 'release-drafter.prerelease.yml',
     prerelease: true,
     'prerelease-identifier': 'beta',
     publish: true,
@@ -50,7 +51,7 @@ const publishBetaJob = new ReusableWorkflowCallJob('PublishBetaPackages', {
 
 const draftStep = new Step({
   name: 'Draft next release',
-  uses: 'release-drafter/release-drafter@v5',
+  uses: 'release-drafter/release-drafter@v6',
   with: {
     commitish: 'main',
   },
@@ -65,14 +66,7 @@ const draftJob = new NormalJob('UpdateReleaseDraft', {
   permissions: {
     contents: 'write',
   },
-})
-  .needs([
-    // This job must run after the beta release because otherwise
-    // release-drafter will delete the draft release.
-    // See: https://github.com/release-drafter/release-drafter/issues/1509
-    betaReleaseJob,
-  ])
-  .addStep(draftStep)
+}).addStep(draftStep)
 
 export const draftWorkflow = new Workflow('draft', {
   name: 'Draft Release',


### PR DESCRIPTION
Currently the prerelease workflow runs before the stable release workflow. I set it up this way because the default behaviour for release-drafter is to modify the most recent draft workflow, irrespective of whether that's a prerelease or stable release draft. Following conversation on https://github.com/release-drafter/release-drafter/issues/1509, this PR now correctly configures release-drafter to allow running the stable and prerelease drafts in parallel.