### PR TITLE
feat(ci): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -37,15 +37,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PublishBetaPackages:
-    uses: ./.github/workflows/publish.yml
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'push'
     permissions:
-      contents: write
-    with:
-      tag_name: ${{ needs.PublishBetaRelease.outputs.tag_name }}
-      target_commitish: ${{ github.sha }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      actions: write
+    steps:
+      - name: Dispatch publish workflow
+        run: |-
+          gh workflow run publish.yml --repo ${{ github.repository }} \
+            -f tag_name="${{ needs.PublishBetaRelease.outputs.tag_name }}" \
+            -f target_commitish="${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     needs:
       - PublishBetaRelease
   UpdateReleaseDraft:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ name: Publish Release
   release:
     types:
       - published
-  workflow_call:
+  workflow_dispatch:
     inputs:
       tag_name:
         required: true
@@ -16,15 +16,13 @@ name: Publish Release
       target_commitish:
         required: true
         type: string
-    secrets:
-      NPM_TOKEN:
-        required: true
 jobs:
   PublishPackages:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,11 +31,11 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
       - name: Run Build
@@ -50,10 +48,6 @@ jobs:
           (cd packages/lib && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
           (cd packages/cli && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
           (cd packages/actions && npm version --no-git-tag-version ${{ inputs.tag_name || github.event.release.tag_name }})
-      - name: Setup npm auth
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish packages
         run: |-
           TAG_NAME="${{ inputs.tag_name || github.event.release.tag_name }}"
@@ -67,8 +61,6 @@ jobs:
             echo "Publishing with latest tag"
             pnpm -r publish --access public --no-git-checks
           fi
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   CommitVersionBump:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/workflows/draft.wac.ts
+++ b/workflows/draft.wac.ts
@@ -1,9 +1,9 @@
 import {
   Workflow,
   NormalJob,
-  ReusableWorkflowCallJob,
   Step,
   expressions as ex,
+  dedentString,
 } from '../packages/lib/src/index.js'
 
 const betaReleaseStep = new Step({
@@ -34,20 +34,33 @@ const betaReleaseJob = new NormalJob('PublishBetaRelease', {
   },
 }).addStep(betaReleaseStep)
 
-const publishBetaJob = new ReusableWorkflowCallJob('PublishBetaPackages', {
-  uses: './.github/workflows/publish.yml',
+// Dispatches publish.yml instead of calling it as a reusable workflow: npm
+// trusted publishing (OIDC) validates the top-level workflow's filename
+// against the package's single trusted publisher, which is publish.yml.
+// GITHUB_TOKEN-triggered events don't start workflows, but workflow_dispatch
+// is exempt from that rule.
+const publishBetaJob = new NormalJob('PublishBetaPackages', {
+  'runs-on': 'ubuntu-latest',
+  'timeout-minutes': 5,
   if: "github.event_name == 'push'",
   permissions: {
-    contents: 'write',
+    actions: 'write',
   },
-  with: {
-    tag_name: ex.expn(`needs.${betaReleaseJob.name}.outputs.tag_name`),
-    target_commitish: ex.expn('github.sha'),
-  },
-  secrets: {
-    NPM_TOKEN: ex.secret('NPM_TOKEN'),
-  },
-}).needs([betaReleaseJob])
+})
+  .addStep(
+    new Step({
+      name: 'Dispatch publish workflow',
+      run: dedentString(`
+        gh workflow run publish.yml --repo ${ex.expn('github.repository')} \\
+          -f tag_name="${ex.expn(`needs.${betaReleaseJob.name}.outputs.tag_name`)}" \\
+          -f target_commitish="${ex.expn('github.sha')}"
+      `),
+      env: {
+        GH_TOKEN: ex.secret('GITHUB_TOKEN'),
+      },
+    }),
+  )
+  .needs([betaReleaseJob])
 
 const draftStep = new Step({
   name: 'Draft next release',

--- a/workflows/publish.wac.ts
+++ b/workflows/publish.wac.ts
@@ -22,13 +22,15 @@ const checkout = new Step({
 const installNode = new Step({
   name: 'Install Node',
   uses: 'actions/setup-node@v4',
-  with: { 'node-version': 20 },
+  // npm trusted publishing (OIDC) requires Node >= 22.14
+  with: { 'node-version': 24 },
 })
 
 const installPnpm = new Step({
   name: 'Install pnpm',
   uses: 'pnpm/action-setup@v4',
-  with: { version: 9 },
+  // pnpm 10 supports OIDC trusted publishing; reads the same v9 lockfile
+  with: { version: 10 },
 })
 
 const installDependencies = new Step({
@@ -54,14 +56,10 @@ const bumpVersions = new Step({
   `),
 })
 
-const setupNpmAuth = new Step({
-  name: 'Setup npm auth',
-  run: 'echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc',
-  env: {
-    NPM_TOKEN: ex.secret('NPM_TOKEN'),
-  },
-})
-
+// Auth is handled by npm trusted publishing (OIDC): the job's id-token
+// permission lets pnpm mint a short-lived token from the runner's OIDC
+// identity. The trusted publisher configured on npmjs.com must reference
+// this workflow file (publish.yml).
 const publishPackages = new Step({
   name: 'Publish packages',
   run: dedentString(`
@@ -77,9 +75,6 @@ const publishPackages = new Step({
       pnpm -r publish --access public --no-git-checks
     fi
   `),
-  env: {
-    NPM_TOKEN: ex.secret('NPM_TOKEN'),
-  },
 })
 
 const publishJob = new NormalJob('PublishPackages', {
@@ -87,6 +82,7 @@ const publishJob = new NormalJob('PublishPackages', {
   'timeout-minutes': 20,
   permissions: {
     contents: 'write',
+    'id-token': 'write',
   },
 }).addSteps([
   checkout,
@@ -95,7 +91,6 @@ const publishJob = new NormalJob('PublishPackages', {
   installDependencies,
   build,
   bumpVersions,
-  setupNpmAuth,
   publishPackages,
 ])
 
@@ -139,13 +134,14 @@ export const publishWorkflow = new Workflow('publish', {
     release: {
       types: ['published'],
     },
-    workflow_call: {
+    // Dispatched (not workflow_call) by draft.yml for beta releases: npm
+    // trusted publishing validates the top-level workflow's filename, and a
+    // package can only have one trusted publisher — so every publish must
+    // run with publish.yml as the top-level workflow.
+    workflow_dispatch: {
       inputs: {
         tag_name: { required: true, type: 'string' },
         target_commitish: { required: true, type: 'string' },
-      },
-      secrets: {
-        NPM_TOKEN: { required: true },
       },
     },
   },


### PR DESCRIPTION
## Problem

Publishing auths with a long-lived `NPM_TOKEN` secret that keeps expiring — the latest beta publish failed with npm E404 (`PUT .../@github-actions-workflow-ts%2flib - Not found`), which is how npm reports an invalid/expired token for scoped packages.

## Solution

Switch to npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC): the publish job declares `id-token: write` and pnpm exchanges the runner's OIDC identity for a short-lived token at publish time. No stored secrets, and npm generates provenance automatically.

Two structural changes were forced by npm's rules:

- **npm validates the top-level workflow filename, and a package gets exactly one trusted publisher.** Beta publishes previously entered through `draft.yml` → `publish.yml` via `workflow_call`, which would validate as `draft.yml`. `draft.yml` now dispatches `publish.yml` with `gh workflow run` instead (`workflow_dispatch` is exempt from the GITHUB_TOKEN no-recursive-workflows rule), so every publish runs with `publish.yml` as the top-level workflow. `workflow_call`/`NPM_TOKEN` inputs are removed.
- **Trusted publishing needs Node ≥ 22.14 and OIDC-aware pnpm.** The publish job moves to Node 24 and pnpm 10 (still lockfile v9; publishing must stay on pnpm because of `workspace:*` deps).

## What a reviewer should look at

- `workflows/publish.wac.ts` — token steps removed, `id-token: write` added, `workflow_call` → `workflow_dispatch`
- `workflows/draft.wac.ts` — `PublishBetaPackages` is now a dispatch job with `actions: write`
- `.github/workflows/*.yml` are generated from the above

## Setup required before merge (npmjs.com)

For **each** of `@github-actions-workflow-ts/lib`, `/cli`, `/actions`: package Settings → Trusted Publisher → GitHub Actions with org `emmanuelnk`, repo `github-actions-workflow-ts`, workflow `publish.yml`, environment blank. Then delete the `NPM_TOKEN` repo secret.

## Test Plan

Verified locally on Node 24 + pnpm 10.34.5 in an isolated clone: install works (dep build scripts blocked by pnpm 10's default, but the build passes — esbuild binaries come via optionalDependencies), `pnpm -r publish --dry-run` packs all three packages after a version bump, and the packed `cli` tarball rewrites `workspace:*` → the real version. The OIDC exchange itself can only be tested by a real run after the npmjs.com config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)