### PR TITLE
fix(ci): pin lint-staged to the repo's prettier to stop schema-check false positives

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "pnpm dlx prettier --config .prettierrc.json --write"
+      "prettier --config .prettierrc.json --write"
     ]
   },
   "pnpm": {

--- a/packages/lib/src/types/githubActionsWorkflow.ts
+++ b/packages/lib/src/types/githubActionsWorkflow.ts
@@ -54,7 +54,8 @@ export type BranchProtectionRuleEvent = {
  * You can use an array of event types. For more information about each event and their activity types, see https://help.github.com/en/articles/events-that-trigger-workflows#webhook-events.
  */
 export type BranchProtectionRuleEventTypes = (
-  [unknown, ...unknown[]] | string
+  | [unknown, ...unknown[]]
+  | string
 ) &
   ('created' | 'edited' | 'deleted')[]
 /**
@@ -375,7 +376,8 @@ export type PullRequestReviewCommentEvent = {
  * You can use an array of event types. For more information about each event and their activity types, see https://help.github.com/en/articles/events-that-trigger-workflows#webhook-events.
  */
 export type PullRequestReviewCommentEventTypes = (
-  [unknown, ...unknown[]] | string
+  | [unknown, ...unknown[]]
+  | string
 ) &
   ('created' | 'edited' | 'deleted')[]
 /**
@@ -511,7 +513,8 @@ export type StringContainingExpressionSyntax = string
  * You can override the default shell settings in the runner's operating system using the shell keyword. You can use built-in shell keywords, or you can define a custom set of shell options.
  */
 export type Shell =
-  string | ('bash' | 'pwsh' | 'python' | 'sh' | 'cmd' | 'powershell')
+  | string
+  | ('bash' | 'pwsh' | 'python' | 'sh' | 'cmd' | 'powershell')
 /**
  * Using the working-directory keyword, you can specify the working directory of where to run the command.
  */


### PR DESCRIPTION
## Problem

[Schema Change Check run 31616735542](https://github.com/emmanuelnk/github-actions-workflow-ts/actions/runs/31616735542) failed — and bot PR #126 was opened — with a diff that contains no schema change at all, only three union-wrapping formatting flips in the generated types.

Root cause: the lint-staged pre-commit hook ran `pnpm dlx prettier` (unpinned — currently resolves 3.9.6) while `generate-workflow-types` and the schema-change-check workflow format with the repo's pinned prettier 3.5.3. The two versions wrap long unions differently, so every commit of the generated file flipped it to 3.9.6 style, and the next schema check regenerated 3.5.3 style → non-empty diff → false positive.

## Solution

- lint-staged now invokes `prettier` directly, which resolves to the pinned 3.5.3 in `node_modules/.bin` — hook, generation script, and CI all format identically.
- The generated types file is normalized back to the pinned formatting (the 3 hunks from the failed run, no semantic change).

Supersedes and closes #126.

## Test Plan

After the commit (which ran through the fixed hook), `pnpm generate-workflow-types` produces a zero-length diff — the exact check CI performs. All 302 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)